### PR TITLE
Add basic summary card meta for Twitter

### DIFF
--- a/_includes/head/twitter.njk
+++ b/_includes/head/twitter.njk
@@ -1,0 +1,5 @@
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@TimberWP" />
+<meta name="twitter:title" content="Timber for WordPress Documentation" />
+<meta name="twitter:description" content="Create WordPress themes with beautiful OOP code and the Twig Template Engine" />
+<meta name="twitter:image" content="https://repository-images.githubusercontent.com/7413451/06c62480-b95c-11ea-8b35-b5dd97d070f1" />

--- a/_includes/html-head.njk
+++ b/_includes/html-head.njk
@@ -34,4 +34,5 @@
     <script src="{{ '/build/js/app.js'|manifest(mixManifest)|url }}" defer></script>
 
 	{% include 'head/favicons.njk' %}
+	{% include 'head/twitter.njk' %}
 </head>


### PR DESCRIPTION
Adds the Twitter card meta tags in order to have a nice summary card appear when the docs are tweeted