### PR TITLE
Title should be "Extending Twig"

### DIFF
--- a/content/v2/guides/extending-twig.md
+++ b/content/v2/guides/extending-twig.md
@@ -1,5 +1,5 @@
 ---
-title: "Extending Timber"
+title: "Extending Twig"
 order: "1650"
 ---
 


### PR DESCRIPTION
## Issue
The page is titled "Extending Timber", which is already a separate page. This page is more precisely about extending Twig.

## Solution
Change the title to "Extending Twig"

## Impact
This will make the documentation less confusing, and will have no negative side effects.
