### PR TITLE
Remove margin from code blocks inside links

### DIFF
--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -11,8 +11,12 @@ li > code,
 a > code {
 	padding: 3px 5px;
 	background: $grey-dark;
-	margin: 0 2px;
 	border-radius: 2px;
+}
+
+p > code,
+li > code {
+	margin: 0 2px;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -25,6 +29,10 @@ a > code {
 	color: $green-light;
 	@include font-code;
 	border-bottom: 1px solid $green-light;
+}
+
+a:has(> code){
+	margin: 0 2px;
 }
 
 .method-name,


### PR DESCRIPTION
Fixes #68

<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it’s your first).

Do you have updates for the content of the documentation (typos, grammar, spelling)? Please open a new issue in the timber/timber repository: https://github.com/timber/timber/issues/new/choose.
--> 

## Issue
<!-- Description of the problem that this code change is solving -->

See #68 /  see https://share.getcloudapp.com/eDu7ow5w 

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

Remove the horizontal margin on `<code>` blocks, to prevent the strange "wrapping underscores" we see in the docs - https://share.getcloudapp.com/eDu7ow5w. 

Uses CSS "has" to add the horizontal margin back onto the parent link element where the browser supports it, otherwise visual change is minor.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

Little to none, besides being visually nicer.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? -->
Browsers that do no support `:has` will have slightly cozier spacing on text surrounding a `<code>` block

## Considerations
<!-- As we do not live in an ideal world it’s worth to share your thought on how we could make the solution even better. -->
