### PR TITLE
CSS: remove background color from blockquotes

### DIFF
--- a/assets/sass/_content.scss
+++ b/assets/sass/_content.scss
@@ -68,7 +68,6 @@ p.summary {
         margin: 1.5em 0;
 
         & > p {
-            background-color: $white;
             color: $green;
             font-size: 1.4em;
             font-weight: $font-weight-normal;


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it’s your first).

Do you have updates for the content of the documentation (typos, grammar, spelling)? Please open a new issue in the timber/timber repository: https://github.com/timber/timber/issues/new/choose.
--> 

## Issue
https://timber.github.io/docs/getting-started/setup/: blockquote p's have a white background. I don't think that is needed. Let's fix that.

![image](https://github.com/timber/docs/assets/17764157/451fb957-6c1e-4ed3-9553-6c96cb945e87)



## Solution
Remove background color from blockquote p's

![image](https://github.com/timber/docs/assets/17764157/952ed66b-2f9c-4d07-8115-a649099ba34d)

## Impact
Better readability of text.
