### PR TITLE
feat(a11y): add skip to content link

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -9,6 +9,8 @@
 {% include 'html-head.njk' %}
 
 <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
     {% include 'header.njk' %}
 
     <div class="wrapper">
@@ -17,7 +19,7 @@
         <div class="main-container">
             {% include 'version-note.njk' %}
 
-            <main>
+            <main id="main-content">
                 {% block content %}
                 {% endblock %}
             </main>

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -43,3 +43,24 @@ a {
 		}
 	}
 }
+
+/* Same style can be used on both light theme and dark theme. */
+.skip-to-content {
+	position: fixed;
+	top: 1rem;
+	left: 1rem;
+	z-index: -1;
+	padding-inline: 1.75ch;
+	padding-block: 0.75ch;
+	border-radius: 0.5ch;
+	background: #ffe633 !important;
+	font-weight: bold;
+	opacity: 0;
+	color: black !important;
+	border: 3px solid black;
+}
+
+.skip-to-content:focus-visible {
+	opacity: 1;
+	z-index: 1001;
+}


### PR DESCRIPTION
## Issue
No issue.


## Solution

Add a `Skip to content` link to improve accessibility. Same styles are applied to both light theme and dark theme.

<img width="1440" alt="SCR-20241001-lkvz" src="https://github.com/user-attachments/assets/054d0be5-ee47-48f4-aac8-cccc41819164">

<img width="1440" alt="SCR-20241001-llkm" src="https://github.com/user-attachments/assets/da0aaa7c-9471-401c-b791-52e443234b53">



## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

This will improve the UX to users who are navigating Timber documentation website using keyboard or assistive technologies.
