### PR TITLE
chore: Add notes about contributing documentation content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @gchtr @Levdbas
+*.yml   @Levdbas @nlemoine

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,30 @@
 <!--
-First off, hello!
+IMPORTANT!
 
-Thanks for submitting a PR. We love/welcome PRs (especially if it’s your first).
+If you want to contribute content to the documentation, you should create a pull request in the timber/timber repository (https://github.com/timber/timber/). The documentation content lives in the **/docs/** folder of the Timber repository.
 
-Do you have updates for the content of the documentation (typos, grammar, spelling)? Please open a new issue in the timber/timber repository: https://github.com/timber/timber/issues/new/choose.
---> 
+This repository (timber/docs) is only used to build the documentation site. It pulls the documentation content from the Timber repository.
+-->
+
+<!-- Remove this if no related tickets exist. -->
+<!-- You can add the related ticket numbers here using #. Example: #2471 -->
+Related:
+
+- Ticket 1
+- Ticket 2
 
 ## Issue
 <!-- Description of the problem that this code change is solving -->
 
-
 ## Solution
 <!-- Description of the solution that this code changes are introducing to the application. -->
-
 
 ## Impact
 <!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
 
-
 ## Usage Changes
-<!-- Are there are any usage changes that we need to know about? -->
-
+<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
+-->
 
 ## Considerations
-<!-- As we do not live in an ideal world it’s worth to share your thought on how we could make the solution even better. -->
+<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing to Timber Documentation
+
+Please refer to the [README.md](https://github.com/timber/docs/blob/master/README.md) for how to contribute to timber/docs.
+
+> [!IMPORTANT]
+> If you want to **contribute content** to the documentation, you should create a pull request in the [timber/timber repository](https://github.com/timber/timber/). The documentation content lives in the **/docs/** folder of the Timber repository.
+> 
+> This repository (timber/docs) is only used to build the documentation site. It pulls the documentation content from the Timber repository.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository is used to build the documentation pages for [Timber](http://github.com/timber/timber). The documentation is generated using the static site generator [Eleventy](https://www.11ty.io/).
 
+> [!IMPORTANT]
+> If you want to **contribute content** to the documentation, you should create a pull request in the [timber/timber repository](https://github.com/timber/timber/). The documentation content lives in the **/docs/** folder of the Timber repository.
+> 
+> This repository (timber/docs) is only used to build the documentation site. It pulls the documentation content from the Timber repository.
+
 <!-- TOC -->
 
 - [Overview](#overview)
@@ -26,8 +31,6 @@ The documentation consists of:
 
 - **Content pages** imported from the [`docs`](https://github.com/timber/timber/tree/master/docs/) folder of the Timber repository.
 - **Reference pages** for Timber’s PHP classes, which is generated directly from the inline DocBlock documentation of the PHP class files. This is handled by the **generate-docs.sh** file, which uses [Teak](https://github.com/timber/teak) to generate the reference.
-
-If you want to **contribute content** to the documentation, you can create a pull request in the [Timber repository](https://github.com/timber/timber/).
 
 ## Writing docs
 


### PR DESCRIPTION
## Issue

In https://github.com/timber/docs/pull/85, @jasalt mentioned that we don’t provide enough warnings before someone contributes content to the documentation.

I think he’s right.

## Solution

- Update README with warning
- Update pull request template with the warning
- Add CONTRIBUTING.md

If you want to preview the README with the warning, check out the branch: https://github.com/timber/docs/tree/chore-pr-warnings.